### PR TITLE
Fix redundant jQuery wrapping in requestedPanel

### DIFF
--- a/src/js/_enqueues/admin/site-health.js
+++ b/src/js/_enqueues/admin/site-health.js
@@ -61,7 +61,7 @@ jQuery( function( $ ) {
 		if ( hash ) {
 			var requestedPanel = $( hash );
 			if ( requestedPanel.length ) {
-				$( requestedPanel ).attr( 'aria-expanded', 'true' );
+				requestedPanel.attr('aria-expanded', 'true');
 				$( '#' + requestedPanel.attr( 'aria-controls' ) ).attr( 'hidden', false );
 			}
 		}


### PR DESCRIPTION
### Summary
This PR removes an unnecessary jQuery wrapper around `requestedPanel` when setting `aria-expanded`. Since `requestedPanel` is already a jQuery object, wrapping it again with `$()` is redundant.

### Changes Made:
- Removed redundant `$()` in `$( requestedPanel ).attr( 'aria-expanded', 'true' );`
- Ensured correct attribute handling without extra jQuery processing.

### Trac Ticket:
[https://core.trac.wordpress.org/ticket/62846](https://core.trac.wordpress.org/ticket/62846)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
